### PR TITLE
Fix inaccurate gateway name on medium gate pearl recipes

### DIFF
--- a/src/main/resources/data/gateways/recipes/blaze_gate.json
+++ b/src/main/resources/data/gateways/recipes/blaze_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:blaze_gate"
+  "gateway": "gateways:blaze_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/creeper_gate.json
+++ b/src/main/resources/data/gateways/recipes/creeper_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:creeper_gate"
+  "gateway": "gateways:creeper_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/enderman_gate.json
+++ b/src/main/resources/data/gateways/recipes/enderman_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:enderman_gate"
+  "gateway": "gateways:enderman_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/ghast_gate.json
+++ b/src/main/resources/data/gateways/recipes/ghast_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:ghast_gate"
+  "gateway": "gateways:ghast_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/magma_cube_gate.json
+++ b/src/main/resources/data/gateways/recipes/magma_cube_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:magma_cube_gate"
+  "gateway": "gateways:magma_cube_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/shulker_gate.json
+++ b/src/main/resources/data/gateways/recipes/shulker_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:shulker_gate"
+  "gateway": "gateways:shulker_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/skeleton_gate.json
+++ b/src/main/resources/data/gateways/recipes/skeleton_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:skeleton_gate"
+  "gateway": "gateways:skeleton_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/slime_gate.json
+++ b/src/main/resources/data/gateways/recipes/slime_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:slime_gate"
+  "gateway": "gateways:slime_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/spider_gate.json
+++ b/src/main/resources/data/gateways/recipes/spider_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:spider_gate"
+  "gateway": "gateways:spider_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/witch_gate.json
+++ b/src/main/resources/data/gateways/recipes/witch_gate.json
@@ -23,5 +23,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:witch_gate"
+  "gateway": "gateways:witch_gate_normal"
 }

--- a/src/main/resources/data/gateways/recipes/zombie_gate.json
+++ b/src/main/resources/data/gateways/recipes/zombie_gate.json
@@ -17,5 +17,5 @@
   "result": {
     "item": "gateways:gate_pearl"
   },
-  "gateway": "gateways:zombie_gate"
+  "gateway": "gateways:zombie_gate_normal"
 }


### PR DESCRIPTION
Switched the gateway IDs for their newer versions.

Fixes #33 

`sd '(.+)_gate' '${1}_gate_normal' *gate.json`