### PR TITLE
Fix XP orb spawning to use queue system to prevent client lag on large amounts of xp spawns

### DIFF
--- a/src/main/java/dev/shadowsoffire/gateways/entity/GatewayEntity.java
+++ b/src/main/java/dev/shadowsoffire/gateways/entity/GatewayEntity.java
@@ -48,6 +48,7 @@ import net.minecraft.world.BossEvent.BossBarOverlay;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
@@ -80,6 +81,7 @@ public abstract class GatewayEntity extends Entity implements IEntityWithComplex
     protected DynamicHolder<Gateway> gate;
     protected float clientScale = 0F;
     protected Queue<ItemStack> undroppedItems = new ArrayDeque<>();
+    protected Queue<Integer> undroppedXP = new ArrayDeque<>();
     protected FailureReason failureReason;
 
     /**
@@ -219,10 +221,17 @@ public abstract class GatewayEntity extends Entity implements IEntityWithComplex
             }
             this.entityData.set(ENEMIES, enemies.size());
 
-            if (this.tickCount % 4 == 0 && !this.undroppedItems.isEmpty()) {
-                for (int i = 0; i < this.getDropCount(); i++) {
+            if (this.tickCount % 4 == 0 && (!this.undroppedItems.isEmpty() || !this.undroppedXP.isEmpty())) {
+                // Spawn items
+                int itemsToSpawn = Math.min(this.getDropCount(), this.undroppedItems.size());
+                for (int i = 0; i < itemsToSpawn; i++) {
                     this.spawnItem(this.undroppedItems.remove());
-                    if (this.undroppedItems.isEmpty()) break;
+                }
+
+                // Spawn XP orbs in parallel - at least 3x faster than items (30 vs 3-10)
+                int xpToSpawn = Math.min(this.getXPDropCount(), this.undroppedXP.size());
+                for (int i = 0; i < xpToSpawn; i++) {
+                    this.spawnXPOrb(this.undroppedXP.remove());
                 }
             }
 
@@ -272,6 +281,14 @@ public abstract class GatewayEntity extends Entity implements IEntityWithComplex
 
     protected int getDropCount() {
         return 3 + this.undroppedItems.size() / 100;
+    }
+
+    /**
+     * Returns the number of XP orbs to spawn per tick cycle.
+     * Spawns at least 3x faster than items to prevent long delays with large XP rewards.
+     */
+    protected int getXPDropCount() {
+        return 30; // Minimum 3x faster than max item drops (which is 3-10)
     }
 
     /**
@@ -404,6 +421,12 @@ public abstract class GatewayEntity extends Entity implements IEntityWithComplex
             stacks.add(s.save(this.registryAccess()));
         }
         tag.put("queued_stacks", stacks);
+        int[] xpArray = new int[this.undroppedXP.size()];
+        int xpIdx = 0;
+        for (Integer xp : this.undroppedXP) {
+            xpArray[xpIdx++] = xp;
+        }
+        tag.putIntArray("queued_xp", xpArray);
         tag.putInt("lives", this.getRemainingLives());
         tag.putInt("nearby_player_timer", this.nearbyPlayerTimer);
     }
@@ -439,6 +462,13 @@ public abstract class GatewayEntity extends Entity implements IEntityWithComplex
                 if (!stack.isEmpty()) {
                     this.undroppedItems.add(stack);
                 }
+            }
+        }
+        if (tag.contains("queued_xp")) {
+            this.undroppedXP.clear();
+            int[] xpArray = tag.getIntArray("queued_xp");
+            for (int xp : xpArray) {
+                this.undroppedXP.add(xp);
             }
         }
         if (tag.contains("lives")) this.setRemainingLives(tag.getInt("lives"));
@@ -540,6 +570,17 @@ public abstract class GatewayEntity extends Entity implements IEntityWithComplex
         i.setDeltaMovement(Mth.nextDouble(this.random, -0.15, 0.15), 0.4, Mth.nextDouble(this.random, -0.15, 0.15));
         this.level().addFreshEntity(i);
         this.level().playSound(null, i.getX(), i.getY(), i.getZ(), GatewayObjects.GATE_WARP, SoundSource.HOSTILE, 0.25F, 2.0F);
+    }
+
+    public void spawnXPOrb(int value) {
+        ExperienceOrb orb = new ExperienceOrb(this.level(), this.getX() + Mth.nextDouble(this.random, -0.5, 0.5), this.getY() + 1.5, this.getZ() + Mth.nextDouble(this.random, -0.5, 0.5), value);
+        orb.setDeltaMovement(Mth.nextDouble(this.random, -0.15, 0.15), 0.4, Mth.nextDouble(this.random, -0.15, 0.15));
+        this.level().addFreshEntity(orb);
+        this.level().playSound(null, orb.getX(), orb.getY(), orb.getZ(), GatewayObjects.GATE_WARP, SoundSource.HOSTILE, 0.25F, 2.0F);
+    }
+
+    public void queueXP(int value) {
+        this.undroppedXP.add(value);
     }
 
     public void spawnCompletionItem(ItemStack stack) {

--- a/src/main/java/dev/shadowsoffire/gateways/entity/NormalGatewayEntity.java
+++ b/src/main/java/dev/shadowsoffire/gateways/entity/NormalGatewayEntity.java
@@ -46,7 +46,7 @@ public class NormalGatewayEntity extends GatewayEntity {
 
     @Override
     public boolean isCompleted() {
-        return this.undroppedItems.isEmpty() && this.isLastWave();
+        return this.undroppedItems.isEmpty() && this.undroppedXP.isEmpty() && this.isLastWave();
     }
 
     @Override

--- a/src/main/java/dev/shadowsoffire/gateways/gate/Reward.java
+++ b/src/main/java/dev/shadowsoffire/gateways/gate/Reward.java
@@ -308,6 +308,8 @@ public interface Reward extends CodecProvider<Reward> {
      */
     public static record ExperienceReward(int xp, int orbSize) implements Reward {
 
+        public static final int MAX_ORB_VALUE = 32767; // Maximum value for a 16-bit signed integer
+
         public static Codec<ExperienceReward> CODEC = RecordCodecBuilder.create(inst -> inst
             .group(
                 Codec.INT.fieldOf("experience").forGetter(ExperienceReward::xp),
@@ -317,9 +319,13 @@ public interface Reward extends CodecProvider<Reward> {
         @Override
         public void generateLoot(ServerLevel level, GatewayEntity gate, Player summoner, Consumer<ItemStack> list) {
             int remaining = this.xp;
+            // Clamp orbSize to the maximum XP orb value
+            int clampedOrbSize = Math.min(this.orbSize, MAX_ORB_VALUE);
+
             while (remaining > 0) {
-                remaining -= orbSize;
-                level.addFreshEntity(new ExperienceOrb(level, gate.getX(), gate.getY(), gate.getZ(), orbSize));
+                int orbValue = Math.min(remaining, clampedOrbSize);
+                gate.queueXP(orbValue);
+                remaining -= orbValue;
             }
         }
 


### PR DESCRIPTION
This commit fixes all XP orb spawning issues by implementing a proper queue system and respecting Minecraft's 16-bit integer limit.

## Problems Fixed

1. **All XP orbs spawned instantly**
   - Previously: Loop spawned all orbs immediately in one tick
   - Now: XP orbs queue and spawn gradually over time

2. **Doesn't respect 32,767 max orb value**
   - Previously: Always used orbSize, never considered limit
   - Now: Clamps to MAX_ORB_VALUE = 32767 (16-bit signed int)

3. **Last orb value bug**
   - Previously: 2502 XP with size 5 → 501×5 = 2505 XP (3 extra!)
   - Now: 2502 XP with size 5 → 500×5 + 1×2 = 2502 XP ✓

4. **XP orbs spawn at least 3x faster than items**
   - Previously: Items spawned at 3-10 per cycle
   - Now: XP spawns at 30 per cycle (minimum 3x faster)
   - Prevents long delays with large XP rewards

## Implementation

**GatewayEntity.java:**
- Added `Queue<Integer> undroppedXP` field
- Added `spawnXPOrb(int value)` method
- Added `queueXP(int value)` method
- Added `getXPDropCount()` returning 30 (3x faster than items)
- Updated tick() to spawn XP orbs in parallel with items
- Added NBT serialization for XP queue (save/load)
- Added ExperienceOrb import

**NormalGatewayEntity.java:**
- Updated `isCompleted()` to check XP queue is empty

**Reward.java (ExperienceReward):**
- Added `MAX_ORB_VALUE = 32767` constant
- Changed to queue XP instead of spawning directly
- Fixed remainder calculation: `Math.min(remaining, clampedOrbSize)`
- Respects 32,767 limit by clamping orbSize

## Technical Details

XP orbs now follow same pattern as items:
- Queue during reward generation
- Spawn gradually every 4 ticks via tick()
- Persist across world reloads (NBT)
- Gateway waits for all XP to spawn before completing

Spawn rate: 30 XP orbs per 4 ticks (vs 3-10 items per 4 ticks)

Fixes: All reported XP orb spawning issues